### PR TITLE
Ghc 7.10.1 compatibility

### DIFF
--- a/pubnub.cabal
+++ b/pubnub.cabal
@@ -17,7 +17,7 @@ cabal-version:          >=1.10
 library
   exposed-modules:      Network.Pubnub, Network.Pubnub.Types
 
-  build-depends:        base >=4.6 && <4.7
+  build-depends:        base >=4.6 && <4.9
                         , aeson >= 0.7.0.0
                         , conduit >= 1.1.0.2
                         , conduit-extra >= 1.1.0
@@ -48,7 +48,8 @@ executable hello_world
   ghc-options:          -Wall
   main-is:              Main.hs
   default-language:     Haskell2010
-  build-depends:        base ==4.6.*, Cabal >= 1.16.0
+  build-depends:        base >=4.6 && <4.9
+                        , Cabal >= 1.16.0
                         , pubnub
                         , aeson >= 0.6.2.1
                         , text >= 0.11.1
@@ -58,7 +59,8 @@ executable chat
   ghc-options:          -Wall
   main-is:              Main.hs
   default-language:     Haskell2010
-  build-depends:        base ==4.6.*, Cabal >= 1.16.0
+  build-depends:        base >=4.6 && <4.9
+                        , Cabal >= 1.16.0
                         , aeson >= 0.6.2.1
                         , bytestring >= 0.10.0.2
                         , async >= 2.0.1.4
@@ -70,7 +72,8 @@ executable test-pubnub-haskell
   ghc-options:          -Wall
   main-is:              Test.hs
   default-language:     Haskell2010
-  build-depends:        base ==4.6.*, Cabal >= 1.16.0
+  build-depends:        base >=4.6 && <4.9
+                        , Cabal >= 1.16.0
                         , pubnub
                         , HUnit
                         , QuickCheck
@@ -85,7 +88,8 @@ test-suite Tests
   main-is:              Test.hs
   Type:                 exitcode-stdio-1.0
   default-language:     Haskell2010
-  build-depends:        base ==4.6.*, Cabal >= 1.16.0
+  build-depends:        base >=4.6 && <4.9
+                        , Cabal >= 1.16.0
                         , pubnub
                         , HUnit
                         , QuickCheck
@@ -93,4 +97,4 @@ test-suite Tests
                         , tasty
                         , tasty-hunit
                         , tasty-quickcheck
-                        , tasty-smallcheck                        
+                        , tasty-smallcheck

--- a/src/Network/Pubnub.hs
+++ b/src/Network/Pubnub.hs
@@ -133,7 +133,7 @@ subscribeInternal pn subOpts =
       awaitForever (\x ->
                        case decode (L.fromStrict x) of
                          Just (SubscribeResponse (resp, _)) -> do
-                           _ <- liftIO $ mapM (onMsg subOpts) resp
+                           _ <- liftIO $ mapM (onMsg subOpts) (resp ++ [])
                            return ()
                          Nothing ->
                            return ())


### PR DESCRIPTION
In GHC 7.10.1 `mapM` has been generalized to:

```
mapM :: (Monad m, Traversable t) => (a -> m b) -> t a -> m (t b)
```

Since I didn't know the type of resp, in my second commit I've forced a list concatenation to help the typechecker. Obviously that commit must be changed with the appropriate type signature, and not using that hack. 
